### PR TITLE
Fix and improve Go example

### DIFF
--- a/_includes/script-examples/github-api/go.md
+++ b/_includes/script-examples/github-api/go.md
@@ -20,7 +20,6 @@ import (
 )
 
 type signal struct {
-	ID      int64  `json:"id"`      // Not used when creating a signal
 	Pid     string `json:"pid"`     // DK5QPID
 	ZoneID  string `json:"zoneId"`  // KEY_A, KEY_B, etc...
 	Name    string `json:"name"`    // message title
@@ -74,7 +73,6 @@ func sendSignal() {
 
 	// Signal to be sent:  A key set to blue color
 	oneSignal := signal{
-		ID:      0,
 		Pid:     "DK5QPID",
 		ZoneID:  "KEY_A",
 		Name:    "Hello oneSignal",

--- a/_includes/script-examples/github-api/go.md
+++ b/_includes/script-examples/github-api/go.md
@@ -1,7 +1,7 @@
 ```go
 // The github-api and the oauth api for golang was used for this program.
-// The first part is to check if there are notifications from github, 
-// the second part is to send the signal if there are.
+// The first part is to check if there are notifications from github,
+// the second part is to send the signal if there are any.
 
 package main
 
@@ -20,13 +20,13 @@ import (
 )
 
 type signal struct {
-	ID           int64  `json:"id"`           // Not used when creating a signal
-	Pid          string `json:"pid"`          // DK5QPID
-	ZoneID       string `json:"zoneId"`       // KEY_A, KEY_B, etc...
-	Name         string `json:"name"`         // message title
-	Message      string `json:"message"`      // message body
-	Effect       string `json:"effect"`       // e.g. SET_COLOR, BLINK, etc...
-	Color        string `json:"color"`        // color in hex format. E.g.: "#FF0044"
+	ID      int64  `json:"id"`      // Not used when creating a signal
+	Pid     string `json:"pid"`     // DK5QPID
+	ZoneID  string `json:"zoneId"`  // KEY_A, KEY_B, etc...
+	Name    string `json:"name"`    // message title
+	Message string `json:"message"` // message body
+	Effect  string `json:"effect"`  // e.g. SET_COLOR, BLINK, etc...
+	Color   string `json:"color"`   // color in hex format. E.g.: "#FF0044"
 }
 
 func checkErr(err error) {
@@ -51,7 +51,7 @@ func getAuth() *github.Client {
 
 func getNotif(client *github.Client) []*github.Notification {
 	ctx := context.Background()
-	notifs, _, err := client.GetActivity().ListNotifications(ctx, nil)
+	notifs, _, err := client.Activity.ListNotifications(ctx, nil)
 	checkErr(err)
 
 	return notifs
@@ -75,14 +75,15 @@ func sendSignal() {
 	port := "27301" // Q desktop public API port #.
 
 	// Signal to be sent:  A key set to blue color
-	oneSignal := signal{0,
-		"DK5QPID",
-		"KEY_A",
-		"Hello oneSignal",
-		"Notification on your github",
-		"SET_COLOR",
-		"#00F",
-		true}
+	oneSignal := signal{
+		ID:      0,
+		Pid:     "DK5QPID",
+		ZoneID:  "KEY_A",
+		Name:    "Hello oneSignal",
+		Message: "Notification on your github",
+		Effect:  "SET_COLOR",
+		Color:   "#00F",
+	}
 
 	// Encode to JSON
 	signalJSON := new(bytes.Buffer)

--- a/_includes/script-examples/github-api/go.md
+++ b/_includes/script-examples/github-api/go.md
@@ -38,8 +38,7 @@ func checkErr(err error) {
 /**
  * this function is used to get Authentification using a oauth token
  */
-func getAuth() *github.Client {
-	ctx := context.Background()
+func getAuth(ctx context.Context) *github.Client {
 	// put your own OAuth Token
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "PUT_YOUR_OWN_OAUTH_TOKEN"})
 
@@ -49,8 +48,7 @@ func getAuth() *github.Client {
 	return client
 }
 
-func getNotif(client *github.Client) []*github.Notification {
-	ctx := context.Background()
+func getNotif(ctx context.Context, client *github.Client) []*github.Notification {
 	notifs, _, err := client.Activity.ListNotifications(ctx, nil)
 	checkErr(err)
 
@@ -60,9 +58,9 @@ func getNotif(client *github.Client) []*github.Notification {
 /**
  * this function is used to know if there are notifications
  */
-func isNotification(client *github.Client) bool {
+func isNotification(ctx context.Context, client *github.Client) bool {
 	isNotif := false
-	notifs := getNotif(client)
+	notifs := getNotif(ctx, client)
 
 	if len(notifs) > 0 {
 		isNotif = true
@@ -101,14 +99,16 @@ func sendSignal() {
 }
 
 func main() {
+	ctx := context.Background()
+
 	// first we get authentification
-	client := getAuth()
+	client := getAuth(ctx)
 	// this is to make sure that the signal is sent only when there are new notifications
 	isSignalSent := false
 	for true {
 		// then we check if there is a notification
 		// if there are notifications and the signal was not send, we send the signal
-		if isNotif := isNotification(client); isNotif && !isSignalSent {
+		if isNotif := isNotification(ctx, client); isNotif && !isSignalSent {
 			sendSignal()
 			isSignalSent = true
 			// if there is no notifications, we reset the flag that tells if the signal was sent or not


### PR DESCRIPTION
The first patch in the series fixes issues that prevented the code from building:

*   The `signal` literal contained too many fields.
*   The `github.Client` does not have a `GetActivity()` method.

The remaining commits simplify and improve the coding style of the example.