### PR TITLE
Travis CI: Fix Ruby/Rubygem version SNAFU.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ node_js:
 - '8.1'
 sudo: required
 before_install:
-- rvm install 2.3.0
-- rvm use 2.3.0
+- rvm install 2.3.8
+- rvm use 2.3.8
 - sudo update-ca-certificates
 - sudo apt-get install libcurl4-openssl-dev
 - "./tool/before_install.sh"

--- a/get-started/marketplace-tutorial.md
+++ b/get-started/marketplace-tutorial.md
@@ -9,6 +9,8 @@ permalink: /get-started/marketplace-tutorial/
 
 </div>
 
+<!--
 ## Next step
 
 [Next step: Watch profile settings video]({{site.baseurl}}/get-started/creating-and-switching-profiles-tutorial/)
+-->

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -3,6 +3,9 @@
 # Fast fail the script on failures.
 set -e
 
+echo "Installing rubygems 2.7.10..."
+gem update --system '2.7.10'
+
 echo "Installing jekyll..."
 gem install bundler
 bundle install


### PR DESCRIPTION
Pin Ruby to version 2.3.8 and Rubygem to 2.7.10. The Rubygem version provided by TravisCI failed to install bundles.

I have literally zero experience with Ruby and have no idea what I'm doing. If this is stupid and the problem should be fixed differently, please let me know.